### PR TITLE
Use forked boardgame.io temporarily to use InitializeGame

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -387,9 +387,8 @@
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
     "boardgame.io": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/boardgame.io/-/boardgame.io-0.33.1.tgz",
-      "integrity": "sha512-hLVXYD/ICKx28SetcKo2Miph0TjBL95LXdmElDPyc9zLJy2EPr287pCnYrAoW/lBLLcO57kbgNalFFRYw+E2QQ==",
+      "version": "github:qsona/boardgame.io#05a1b90ca4de6e5b969e35be36c3551a0dca4eac",
+      "from": "github:qsona/boardgame.io#for_slack_integration",
       "requires": {
         "@koa/cors": "^2.2.1",
         "flatted": "^0.2.3",
@@ -1795,9 +1794,9 @@
       "integrity": "sha512-vM5FkMHamTYmVYeAujypihuPrJQDtaUIlKeeVb1AMJ73OZLtWiF7GprqrjxD0gJWT53W9JfqXxf97nXQjMQkqA=="
     },
     "nanoid": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.1.tgz",
-      "integrity": "sha512-0YbJdaL4JFoejIOoawgLcYValFGJ2iyUuVDIWL3g8Es87SSOWFbWdRUMV3VMSiyPs3SQ3QxCIxFX00q5DLkMCw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.2.tgz",
+      "integrity": "sha512-q0iKJHcLc9rZg/qtJ/ioG5s6/5357bqvkYCpqXJxpcyfK7L5us8+uJllZosqPWou7l6E1lY2Qqoq5ce+AMbFuQ=="
     },
     "negotiator": {
       "version": "0.6.2",
@@ -2073,9 +2072,9 @@
       }
     },
     "react-is": {
-      "version": "16.10.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
-      "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA=="
     },
     "redux": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "assert-never": "^1.2.0",
-    "boardgame.io": "^0.33.1",
+    "boardgame.io": "qsona/boardgame.io#for_slack_integration",
     "botbuilder-adapter-slack": "^1.0.4",
     "botbuilder-storage-mongodb": "^0.9.5",
     "botkit": "^4.5.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,3 +8,20 @@ import { registerGame } from './SlackGameManager'
 registerGame('tic-tac-toe', TicTacToe, TicTacToeCUIGame);
 
 start();
+
+// import {
+//   getGameInfo,
+//   create,
+//   destroy,
+//   join,
+//   leave,
+//   start as s,
+//   processMove
+// } from './SlackGameManager';
+
+// var result: any = create('tic-tac-toe', 'a', 'a');
+// console.log('c', result);
+// result = join('a', 'b');
+// console.log('j', result);
+// result = s('a', 'a');
+// console.log(result);


### PR DESCRIPTION
On boardgame.io v0.33, `InitializeGame` is not exposed. It will be exposed again (See [gitter](https://gitter.im/boardgame-io/General?at=5d96a71d37073b36a067d5d8)) so this is a temporary fix.